### PR TITLE
ci: change the registry to `ghcr.io` and publish the image under the sunken-dev namespace

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -6,13 +6,16 @@ on:
       - main
 
 env:
-  IMAGE_NAME: ch4s3r/mdbook-extended
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
-
+  build-and-push-image:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -23,14 +26,15 @@ jobs:
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build-and-push

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ### Base image which contains mdbook with all extensions
 ```shell
-docker buildx build -t ch4s3r/mdbook-extended .
+docker buildx build -t sunken-dev/mdbook-extended .
 ```
 
 ### Example dockerfile with nginx
 
 ```Dockerfile
-FROM ch4s3r/mdbook-extended AS builder
+FROM sunken-dev/mdbook-extended AS builder
 WORKDIR /app
 COPY . .
 RUN ["mdbook", "build"]


### PR DESCRIPTION
Change the registry to `ghcr.io`.
Change image to be published as `sunken-dev/mdbook-extended`.