### PR TITLE
chore: remove support for mdbook-pdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN cargo install --locked \
     mdbook-mermaid@0.12.6 \
     mdbook-admonish@1.8.0  \
     mdbook-linkcheck@0.7.7  \
-    mdbook-pdf@0.1.5  \
     mdbook@0.4.25
 
 FROM gcr.io/distroless/cc

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Automatically updated [mdbook](https://github.com/rust-lang/mdBook) docker image
 - mdbook-mermaid
 - mdbook-admonish
 - mdbook-linkcheck
-- mdbook-pdf
 
 ## Why?
 


### PR DESCRIPTION
PDF generation is not working as we don't copy the chrome headless browser into the final image.